### PR TITLE
👷 Add Github Actions Workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
 jobs:
   actions:
+    runs-on: ubuntu-latest
     name: Review Dog - Lint GitHub Action Workflows
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+on:
+  pull_request:
+    types: [synchronize, edited, opened]
+  push:
+    branches: [main]
+jobs:
+  actions:
+    name: Review Dog - Lint GitHub Action Workflows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Review Dog - actionlint
+        uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: GreenTF/upload-thunderstore-package@v4.3
+        with:
+          namespace: Gongo
+          token: ${{ secrets.THUNDERSTORE_TOKEN }}
+          version: ${{github.ref_name}}
+          name: Gongo_Company
+          website: ""
+          categories: |
+            suits
+            cosmetics

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": [
     "x753-More_Suits-1.3.3",
     "BepInEx-BepInExPack-5.4.2100",
-	"Verity-TooManySuits-1.0.3"
+    "Verity-TooManySuits-1.0.3"
   ]
 }


### PR DESCRIPTION
These workflows do the following:

1. Allows us to use the GitHub Releases system for publishing a release
2. Validates that any GitHub Actions we have are valid at all times.

This PR also fixes a tabs vs spaces mismatch thing in the `manifest.json`.

> [!NOTE]
> If this is merged, an admin of the Gongo team on thunderstore will need to generate a Service Account API Token, and set it  under this repositories secrets with the name `THUNDERSTORE_TOKEN`.
